### PR TITLE
Customizable container div

### DIFF
--- a/src/lib/Tooltip.svelte
+++ b/src/lib/Tooltip.svelte
@@ -6,7 +6,10 @@
   export let left = false;
   export let active = false;
   export let color = "#0f172a";
-  export let container = ""
+  let className="";
+  let tipStyle="";
+  export { className as class };
+  export { tipStyle as style };
 
   let arrowTopGap = 0;
 
@@ -78,7 +81,7 @@
   };
 </script>
 
-<span class={`tooltip-slot ${container}`} use:tooltip>
+<span class="tooltip-slot {className}" style={tipStyle} use:tooltip>
   <slot />
   <span class:tooltip={true} class:active {...$$restProps}>
     {#if tip}

--- a/src/lib/Tooltip.svelte
+++ b/src/lib/Tooltip.svelte
@@ -6,6 +6,7 @@
   export let left = false;
   export let active = false;
   export let color = "#0f172a";
+  export let container = ""
 
   let arrowTopGap = 0;
 
@@ -77,7 +78,7 @@
   };
 </script>
 
-<span class="tooltip-slot" use:tooltip>
+<span class={`tooltip-slot ${container}`} use:tooltip>
   <slot />
   <span class:tooltip={true} class:active {...$$restProps}>
     {#if tip}


### PR DESCRIPTION
# Implemented the feature to allow the user to change the container class as he prefer.

### As this could not be possibile without it:

### Current:
```
<Tooltip tip="This is a button" bottom>
    <button class="h-[90%] aspect-square rounded-full ring ring-white hover:scale-[110%] hover:bg-neutral-500/30 hover:cursor-pointer transition-all duration-200 flex items-center justify-center">
        <div class="aspect-square h-[90%]">
            <Plus class="w-full h-full"/>
        </div>
    </button>
</Tooltip>
```
### Modified:
```
<Tooltip tip="This is a button" container="h-[90%] aspect-square" bottom>
    <button class="w-full h-full rounded-full ring ring-white hover:scale-[110%] hover:bg-neutral-500/30 hover:cursor-pointer transition-all duration-200 flex items-center justify-center">
        <div class="aspect-square h-[90%]">
            <Plus class="w-full h-full"/>
        </div>
    </button>
</Tooltip>
```
